### PR TITLE
fix(task-mcp): fix mcp tool parser callback share same task instruction issue

### DIFF
--- a/packages/task/task-mcp/src/mcp-tool-parser.ts
+++ b/packages/task/task-mcp/src/mcp-tool-parser.ts
@@ -64,7 +64,7 @@ export class McpToolParser {
         return accTask;
       }, {
         id: genTaskId(),
-        instructions: task.instructions
+        instructions: structuredClone(task.instructions)
       });
       const result = await this.doTask(realTask)
       return {


### PR DESCRIPTION
修复task的callback共享instruction导致第一次变量替换后无法再次替换

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where changes to task instructions could unintentionally affect the original instructions by ensuring each task now uses a separate copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->