### PR TITLE
fix(task-runtime-service): fix style not import in prod mode

### DIFF
--- a/packages/task/task-runtime-service/package.json
+++ b/packages/task/task-runtime-service/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "vite": "^6.0.0",
     "vite-plugin-css-injected-by-js": "^3.5.2",
-    "vite-plugin-dts": "^4.0.0",
-    "vite-plugin-lib-inject-css": "^2.2.2"
+    "vite-plugin-dts": "^4.0.0"
   }
 }

--- a/packages/task/task-runtime-service/package.json
+++ b/packages/task/task-runtime-service/package.json
@@ -16,6 +16,8 @@
   },
   "devDependencies": {
     "vite": "^6.0.0",
-    "vite-plugin-dts": "^4.0.0"
+    "vite-plugin-css-injected-by-js": "^3.5.2",
+    "vite-plugin-dts": "^4.0.0",
+    "vite-plugin-lib-inject-css": "^2.2.2"
   }
 }

--- a/packages/task/task-runtime-service/vite.config.ts
+++ b/packages/task/task-runtime-service/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     },
     sourcemap: true,
     rollupOptions: {
+      output: {
+        banner: 'import "./index.css";',
+      },
       external: Object.keys(packageJson.dependencies || {}),
     },
   },

--- a/packages/task/task-runtime-service/vite.config.ts
+++ b/packages/task/task-runtime-service/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import packageJson from './package.json';
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 export default defineConfig({
   build: {
     lib: {
@@ -11,9 +12,6 @@ export default defineConfig({
     },
     sourcemap: true,
     rollupOptions: {
-      output: {
-        banner: 'import "./index.css";',
-      },
       external: Object.keys(packageJson.dependencies || {}),
     },
   },
@@ -21,5 +19,6 @@ export default defineConfig({
     dts({
       tsconfigPath: './tsconfig.json',
     }),
+    cssInjectedByJsPlugin(),
   ],
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled CSS-injected-by-JS support in the task runtime service build so styles are injected and available at runtime.
  * Added development dependencies to support CSS injection during packaging and library builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->